### PR TITLE
P-value: add delta change

### DIFF
--- a/src/main/java/com/yahoo/sketches/pig/tuple/ArrayOfDoublesSketchesToPValueEstimates.java
+++ b/src/main/java/com/yahoo/sketches/pig/tuple/ArrayOfDoublesSketchesToPValueEstimates.java
@@ -70,8 +70,8 @@ public class ArrayOfDoublesSketchesToPValueEstimates extends EvalFunc<Tuple> {
       Map<String, Double> map = new HashMap<>();
       // Pass the sampled values for each metric
       map.put(P_VALUE_KEY, tTest.tTest(summaryA[i], summaryB[i]));
-      // The mean delta is equal to A_mean - B_mean
-      map.put(DELTA_KEY, summaryA[i].getMean() - summaryB[i].getMean());
+      // Add the change percent between the means of A and B
+      map.put(DELTA_KEY, relativeChangePercent(summaryA[i].getMean(), summaryB[i].getMean()));
       // Add the map to the tuple
       tuple.set(i, map);
     }
@@ -105,6 +105,17 @@ public class ArrayOfDoublesSketchesToPValueEstimates extends EvalFunc<Tuple> {
     }
 
     return summaryStatistics;
+  }
+
+  /**
+   * Calculate the relative change between two doubles.
+   *
+   * @ a First number.
+   * @ b Second number.
+   * @return Percent difference.
+   */
+  private static double relativeChangePercent(double a, double b) {
+      return (b - a) / Math.abs(a);
   }
 
 }

--- a/src/main/java/com/yahoo/sketches/pig/tuple/ArrayOfDoublesSketchesToPValueEstimates.java
+++ b/src/main/java/com/yahoo/sketches/pig/tuple/ArrayOfDoublesSketchesToPValueEstimates.java
@@ -6,6 +6,8 @@
 package com.yahoo.sketches.pig.tuple;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
 import org.apache.commons.math3.stat.inference.TTest;
@@ -13,6 +15,7 @@ import org.apache.commons.math3.stat.inference.TTest;
 import org.apache.pig.EvalFunc;
 import org.apache.pig.data.DataByteArray;
 import org.apache.pig.data.Tuple;
+import org.apache.pig.data.TupleFactory;
 
 import com.yahoo.memory.Memory;
 import com.yahoo.sketches.tuple.ArrayOfDoublesSketch;
@@ -22,9 +25,13 @@ import com.yahoo.sketches.tuple.ArrayOfDoublesSketches;
 /**
  * Calculate p-values given two ArrayOfDoublesSketch. Each value in the sketch
  * is treated as a separate metric measurement, and a p-value will be generated
- * for each metric.
+ * for each metric, along with the percent difference between the two means.
  */
 public class ArrayOfDoublesSketchesToPValueEstimates extends EvalFunc<Tuple> {
+  /** Key for p-value. */
+  public static final String P_VALUE_KEY = "pValue";
+  /** Key for delta. */
+  public static final String DELTA_KEY = "delta";
 
   @Override
   public Tuple exec(final Tuple input) throws IOException {
@@ -55,17 +62,23 @@ public class ArrayOfDoublesSketchesToPValueEstimates extends EvalFunc<Tuple> {
     final SummaryStatistics[] summaryA = sketchToSummaryStatistics(sketchA, numMetrics);
     final SummaryStatistics[] summaryB = sketchToSummaryStatistics(sketchB, numMetrics);
 
-    // Calculate the p-values
-    final double[] pValues = new double[numMetrics];
+    // Calculate the p-values and the mean deltas
+    final Tuple tuple = TupleFactory.getInstance().newTuple(numMetrics);
     final TTest tTest = new TTest();
     for (int i = 0; i < numMetrics; i++) {
+      // Create the map for this metric
+      Map<String, Double> map = new HashMap<>();
       // Pass the sampled values for each metric
-      pValues[i] = tTest.tTest(summaryA[i], summaryB[i]);
+      map.put(P_VALUE_KEY, tTest.tTest(summaryA[i], summaryB[i]));
+      // The mean delta is equal to A_mean - B_mean
+      map.put(DELTA_KEY, summaryA[i].getMean() - summaryB[i].getMean());
+      // Add the map to the tuple
+      tuple.set(i, map);
     }
 
-    return Util.doubleArrayToTuple(pValues);
+    return tuple;
   }
-  
+
   /**
    * Convert sketch to a summary statistic.
    *
@@ -93,5 +106,5 @@ public class ArrayOfDoublesSketchesToPValueEstimates extends EvalFunc<Tuple> {
 
     return summaryStatistics;
   }
-  
+
 }

--- a/src/test/java/com/yahoo/sketches/pig/tuple/ArrayOfDoublesSketchesToPValueEstimatesTest.java
+++ b/src/test/java/com/yahoo/sketches/pig/tuple/ArrayOfDoublesSketchesToPValueEstimatesTest.java
@@ -18,6 +18,7 @@ import com.yahoo.sketches.tuple.ArrayOfDoublesUpdatableSketchBuilder;
 import org.apache.commons.math3.stat.inference.TTest;
 import org.apache.commons.math3.stat.StatUtils;
 
+import java.util.Map;
 import java.util.Random;
 
 /**
@@ -123,7 +124,9 @@ public class ArrayOfDoublesSketchesToPValueEstimatesTest {
         Assert.assertEquals(resultTuple.size(), 1);
 
         // Check p-value values, with a delta
-        Assert.assertEquals((double) resultTuple.get(0), 0.0043, 0.0001);
+        Assert.assertEquals((double) ((Map) resultTuple.get(0)).get(ArrayOfDoublesSketchesToPValueEstimates.P_VALUE_KEY), 0.0043, 0.0001);
+        // Check mean delta
+        Assert.assertEquals((double) ((Map) resultTuple.get(0)).get(ArrayOfDoublesSketchesToPValueEstimates.DELTA_KEY), 1.034, 0.1);
     }
 
     /**
@@ -179,7 +182,10 @@ public class ArrayOfDoublesSketchesToPValueEstimatesTest {
         Assert.assertEquals(resultTuple.size(), 1);
 
         // Check p-value values, with a delta
-        Assert.assertEquals((double) resultTuple.get(0), expectedPValue, 0.01);
+        Assert.assertEquals((double) ((Map) resultTuple.get(0)).get(ArrayOfDoublesSketchesToPValueEstimates.P_VALUE_KEY), expectedPValue, 0.01);
+        // Check mean delta
+        Assert.assertEquals((double) ((Map) resultTuple.get(0)).get(ArrayOfDoublesSketchesToPValueEstimates.DELTA_KEY), -1000.0, 100);
+
     }
 
     /**
@@ -223,8 +229,13 @@ public class ArrayOfDoublesSketchesToPValueEstimatesTest {
         Assert.assertEquals(resultTuple.size(), 2);
 
         // Check expected p-value values, with a delta
-        Assert.assertEquals((double) resultTuple.get(0), 0.0043, 0.0001);
-        Assert.assertEquals((double) resultTuple.get(1), 0.58, 0.01);
+        Assert.assertEquals((double) ((Map) resultTuple.get(0)).get(ArrayOfDoublesSketchesToPValueEstimates.P_VALUE_KEY), 0.0043, 0.0001);
+        Assert.assertEquals((double) ((Map) resultTuple.get(1)).get(ArrayOfDoublesSketchesToPValueEstimates.P_VALUE_KEY), 0.58, 0.01);
+
+        // Check mean delta
+        Assert.assertEquals((double) ((Map) resultTuple.get(0)).get(ArrayOfDoublesSketchesToPValueEstimates.DELTA_KEY), 1.03, 0.1);
+        Assert.assertEquals((double) ((Map) resultTuple.get(1)).get(ArrayOfDoublesSketchesToPValueEstimates.DELTA_KEY), -1.0, 0.1);
+
     }
 
     /**

--- a/src/test/java/com/yahoo/sketches/pig/tuple/ArrayOfDoublesSketchesToPValueEstimatesTest.java
+++ b/src/test/java/com/yahoo/sketches/pig/tuple/ArrayOfDoublesSketchesToPValueEstimatesTest.java
@@ -126,7 +126,7 @@ public class ArrayOfDoublesSketchesToPValueEstimatesTest {
         // Check p-value values, with a delta
         Assert.assertEquals((double) ((Map) resultTuple.get(0)).get(ArrayOfDoublesSketchesToPValueEstimates.P_VALUE_KEY), 0.0043, 0.0001);
         // Check mean delta
-        Assert.assertEquals((double) ((Map) resultTuple.get(0)).get(ArrayOfDoublesSketchesToPValueEstimates.DELTA_KEY), 1.034, 0.1);
+        Assert.assertEquals((double) ((Map) resultTuple.get(0)).get(ArrayOfDoublesSketchesToPValueEstimates.DELTA_KEY), -0.19, 0.05);
     }
 
     /**
@@ -184,7 +184,7 @@ public class ArrayOfDoublesSketchesToPValueEstimatesTest {
         // Check p-value values, with a delta
         Assert.assertEquals((double) ((Map) resultTuple.get(0)).get(ArrayOfDoublesSketchesToPValueEstimates.P_VALUE_KEY), expectedPValue, 0.01);
         // Check mean delta
-        Assert.assertEquals((double) ((Map) resultTuple.get(0)).get(ArrayOfDoublesSketchesToPValueEstimates.DELTA_KEY), -1000.0, 100);
+        Assert.assertEquals((double) ((Map) resultTuple.get(0)).get(ArrayOfDoublesSketchesToPValueEstimates.DELTA_KEY), 76892, 5000);
 
     }
 
@@ -228,13 +228,13 @@ public class ArrayOfDoublesSketchesToPValueEstimatesTest {
         Assert.assertNotNull(resultTuple);
         Assert.assertEquals(resultTuple.size(), 2);
 
-        // Check expected p-value values, with a delta
+        // Check expected p-value values, and mean deltas
         Assert.assertEquals((double) ((Map) resultTuple.get(0)).get(ArrayOfDoublesSketchesToPValueEstimates.P_VALUE_KEY), 0.0043, 0.0001);
-        Assert.assertEquals((double) ((Map) resultTuple.get(1)).get(ArrayOfDoublesSketchesToPValueEstimates.P_VALUE_KEY), 0.58, 0.01);
+        Assert.assertEquals((double) ((Map) resultTuple.get(0)).get(ArrayOfDoublesSketchesToPValueEstimates.DELTA_KEY), -0.19, 0.05);
 
-        // Check mean delta
-        Assert.assertEquals((double) ((Map) resultTuple.get(0)).get(ArrayOfDoublesSketchesToPValueEstimates.DELTA_KEY), 1.03, 0.1);
-        Assert.assertEquals((double) ((Map) resultTuple.get(1)).get(ArrayOfDoublesSketchesToPValueEstimates.DELTA_KEY), -1.0, 0.1);
+        // Check expected p-value values, and mean deltas
+        Assert.assertEquals((double) ((Map) resultTuple.get(1)).get(ArrayOfDoublesSketchesToPValueEstimates.P_VALUE_KEY), 0.58, 0.01);
+        Assert.assertEquals((double) ((Map) resultTuple.get(1)).get(ArrayOfDoublesSketchesToPValueEstimates.DELTA_KEY), 0.125, 0.01);
 
     }
 


### PR DESCRIPTION
- Changed `ArrayOfDoublesSketchesToPValueEstimates` to return a list of maps, one map for each metric. The map contains keys `pValue` and `delta`. `pValue` is the p-value that the previous UDF returned. `delta` is the percent difference between tuple A (control) and B (treatment).