### PR TITLE
Fixing the Quantiles UDFs to ignore null values.

### DIFF
--- a/src/main/java/com/yahoo/sketches/pig/quantiles/DataToDoublesSketch.java
+++ b/src/main/java/com/yahoo/sketches/pig/quantiles/DataToDoublesSketch.java
@@ -128,7 +128,10 @@ public class DataToDoublesSketch extends EvalFunc<Tuple> implements Accumulator<
       final DoublesUnion union = unionBuilder_.build();
       final DataBag bag = (DataBag) inputTuple.get(0);
       for (final Tuple innerTuple: bag) {
-        union.update((Double) innerTuple.get(0));
+        Object value = innerTuple.get(0);
+        if(value != null) {
+          union.update((Double) value);
+        }
       }
       final DoublesSketch resultSketch = union.getResultAndReset();
       if (resultSketch != null) {
@@ -176,7 +179,10 @@ public class DataToDoublesSketch extends EvalFunc<Tuple> implements Accumulator<
       accumUnion_ = unionBuilder_.build();
     }
     for (final Tuple innerTuple: bag) {
-      accumUnion_.update((Double) innerTuple.get(0));
+      Object value = innerTuple.get(0);
+        if(value != null) {
+          accumUnion_.update((Double) value);
+      }
     }
   }
 
@@ -317,7 +323,10 @@ public class DataToDoublesSketch extends EvalFunc<Tuple> implements Accumulator<
             // It is due to system bagged outputs from multiple mapper Initial functions.
             // The Intermediate stage was bypassed.
             for (final Tuple innerTuple: innerBag) {
-              union.update((Double) innerTuple.get(0));
+              Object value = innerTuple.get(0);
+              if(value != null) {
+                union.update((Double) value);
+              }
             }
           } else if (f0 instanceof DataByteArray) { // inputTuple.bag0.dataTupleN.f0:DBA
             // If field 0 of a dataTuple is a DataByteArray we assume it is a sketch

--- a/src/main/java/com/yahoo/sketches/pig/quantiles/DataToItemsSketch.java
+++ b/src/main/java/com/yahoo/sketches/pig/quantiles/DataToItemsSketch.java
@@ -122,7 +122,10 @@ public abstract class DataToItemsSketch<T> extends EvalFunc<Tuple>
           : ItemsUnion.getInstance(comparator_);
       final DataBag bag = (DataBag) inputTuple.get(0);
       for (final Tuple innerTuple: bag) {
-        union.update(extractValue(innerTuple.get(0)));
+        Object value = innerTuple.get(0);
+        if(value != null) {
+          union.update(extractValue(value));
+        }
       }
       final ItemsSketch<T> resultSketch = union.getResultAndReset();
       if (resultSketch != null) {
@@ -173,7 +176,10 @@ public abstract class DataToItemsSketch<T> extends EvalFunc<Tuple>
         : ItemsUnion.getInstance(comparator_);
     }
     for (final Tuple innerTuple: bag) {
-      accumUnion_.update(extractValue(innerTuple.get(0)));
+      Object value = innerTuple.get(0);
+      if(value != null) {
+        accumUnion_.update(extractValue(value));
+      }
     }
   }
 
@@ -307,7 +313,10 @@ public abstract class DataToItemsSketch<T> extends EvalFunc<Tuple>
             // It is due to system bagged outputs from multiple mapper Initial functions.
             // The Intermediate stage was bypassed.
             for (final Tuple innerTuple: innerBag) {
-              union.update(extractValue(innerTuple.get(0)));
+              Object value = innerTuple.get(0);
+              if(value != null) {
+                union.update(extractValue(value));
+              }
             }
           } else if (f0 instanceof DataByteArray) { // inputTuple.bag0.dataTupleN.f0:DBA
             // If field 0 of a dataTuple is a DataByteArray we assume it is a sketch


### PR DESCRIPTION
This PR adds code to skip null values in the inner bags passed to the UDFs.  This makes the UDFs function the same as the current PIG builtin UDFs. (See the Average function for reference.) 
I note that the other UDFs (frequencies, theta, tuple) seem to skip nulls already so this also brings the quantiles into alignment with the other UDFs.

I also added some unit tests. 